### PR TITLE
feat: using web cache in github graphql api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ gh api graphql -f query="$(cat contributions.graphql)" -f userName=swfz -f from=
 gh api graphql -f query="$(cat ratelimit.graphql)"
 ```
 
-
 - test(vrt)
 
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ https://kusa-image.deno.dev/swfz
 deno run --allow-net --allow-env --watch server.ts
 ```
 
+- query GraphQL
+
+e.g)
+
+```
+gh api graphql -f query="$(cat contributions.graphql)" -f userName=swfz -f from=2022-01-01T00:00:00Z -f to=2022-12-31T23:59:59Z
+gh api graphql -f query="$(cat ratelimit.graphql)"
+```
+
+
 - test(vrt)
 
 ```

--- a/ratelimit.graphql
+++ b/ratelimit.graphql
@@ -1,0 +1,8 @@
+query {
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -37,7 +37,7 @@ const handler = async (request: Request): Promise<Response> => {
     const n = fixPastYears(pastYears);
     for (const [index] of Array(n).entries()) {
       const year = new Date().getFullYear() - index;
-      const data = await getContributions(user, `${year}-01-01T00:00:00Z`, `${year}-12-31T23:59:59Z`);
+      const data = await getContributions(index !== 0, user, `${year}-01-01T00:00:00Z`, `${year}-12-31T23:59:59Z`);
       const event = data.data.user.contributionsCollection.contributionCalendar.isHalloween ? "halloween" : "default";
 
       renderContributions(
@@ -52,7 +52,7 @@ const handler = async (request: Request): Promise<Response> => {
       );
     }
   } else {
-    const data = await getContributions(user, undefined, to ? `${to}T23:59:59Z` : undefined);
+    const data = await getContributions(false, user, undefined, to ? `${to}T23:59:59Z` : undefined);
 
     if (data?.data?.user === null) {
       return new Response(`Could not resolve to a User. ${user}`, {


### PR DESCRIPTION
- 現在の年はcacheを使わない
- キーはuser,from,toをあわせたURL（GraphQLへのAPIアクセスだったのでユニークの単位で設定した）

a4ed305 feat: using web cache in github graphql api
0236701 chore: github ratelimit query
3c03878 chore: Executiong GraphQL query in gh cli
8da8c0a chore: fmt