### PR TITLE
fix(lint): use bare specifiers for imports to resolve lint errors

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,8 @@
 {
+  "imports": {
+    "canvas": "https://deno.land/x/canvas@v1.4.2/mod.ts",
+    "@std/ulid": "jsr:@std/ulid@^1.0.0"
+  },
   "tasks": {
     "dev": "deno run --unstable-kv --allow-net --allow-env --allow-read --watch server.ts",
     "deploy": "deployctl deploy --project=kusa-image --prod server.ts",

--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,2 @@
-import { createCanvas } from "https://deno.land/x/canvas@v1.4.2/mod.ts";
+import { createCanvas } from "canvas";
 export { createCanvas };

--- a/logger.ts
+++ b/logger.ts
@@ -1,4 +1,4 @@
-import { ulid } from "jsr:@std/ulid";
+import { ulid } from "@std/ulid";
 
 const EXPIRE_LOGS_DAYS = 90;
 


### PR DESCRIPTION
0b9aab9 fix(lint): use bare specifiers for imports to resolve lint errors