### PR TITLE
test: add tests for colors module

### DIFF
--- a/colors.ts
+++ b/colors.ts
@@ -54,9 +54,10 @@ const squareColors = (theme: string, event: string) => {
       },
     },
   };
-  const colors = allColors[event] ? allColors[event][theme] : allColors.default[theme];
+  const eventKey: Event = event === "halloween" ? "halloween" : "default";
+  const themeKey: Theme = theme === "dark" ? "dark" : "light";
 
-  return colors;
+  return allColors[eventKey][themeKey];
 };
 
 export { backgroundColor, squareColors, textColor };

--- a/colors_test.ts
+++ b/colors_test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from "@std/assert";
+import { backgroundColor, squareColors, textColor } from "./colors.ts";
+
+Deno.test("backgroundColor", async (t) => {
+  await t.step("dark theme returns black", () => {
+    assertEquals(backgroundColor("dark"), "#000000");
+  });
+  await t.step("light theme returns white", () => {
+    assertEquals(backgroundColor("light"), "#FFFFFF");
+  });
+  await t.step("unknown theme falls back to white", () => {
+    assertEquals(backgroundColor("neon"), "#FFFFFF");
+  });
+});
+
+Deno.test("textColor", async (t) => {
+  await t.step("dark theme returns white", () => {
+    assertEquals(textColor("dark"), "#FFFFFF");
+  });
+  await t.step("light theme returns black", () => {
+    assertEquals(textColor("light"), "#000000");
+  });
+  await t.step("unknown theme falls back to black", () => {
+    assertEquals(textColor("neon"), "#000000");
+  });
+});
+
+Deno.test("squareColors", async (t) => {
+  await t.step("default dark palette", () => {
+    assertEquals(squareColors("dark", "default"), {
+      NONE: "#161b22",
+      FIRST_QUARTILE: "#0e4429",
+      SECOND_QUARTILE: "#006d32",
+      THIRD_QUARTILE: "#26a641",
+      FOURTH_QUARTILE: "#39d353",
+    });
+  });
+  await t.step("default light palette", () => {
+    assertEquals(squareColors("light", "default"), {
+      NONE: "#ebedf0",
+      FIRST_QUARTILE: "#9be9a8",
+      SECOND_QUARTILE: "#40c463",
+      THIRD_QUARTILE: "#30a14e",
+      FOURTH_QUARTILE: "#216e39",
+    });
+  });
+  await t.step("halloween dark palette", () => {
+    assertEquals(squareColors("dark", "halloween"), {
+      NONE: "#161b22",
+      FIRST_QUARTILE: "#631c03",
+      SECOND_QUARTILE: "#bd561d",
+      THIRD_QUARTILE: "#fa7a18",
+      FOURTH_QUARTILE: "#fddf68",
+    });
+  });
+  await t.step("halloween light palette", () => {
+    assertEquals(squareColors("light", "halloween"), {
+      NONE: "#ebedf0",
+      FIRST_QUARTILE: "#ffee4a",
+      SECOND_QUARTILE: "#ffc501",
+      THIRD_QUARTILE: "#fe9600",
+      FOURTH_QUARTILE: "#0c001c",
+    });
+  });
+  await t.step("unknown event falls back to default palette (dark)", () => {
+    assertEquals(squareColors("dark", "xmas"), squareColors("dark", "default"));
+  });
+  await t.step("unknown event falls back to default palette (light)", () => {
+    assertEquals(squareColors("light", "xmas"), squareColors("light", "default"));
+  });
+});

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "imports": {
     "canvas": "https://deno.land/x/canvas@v1.4.2/mod.ts",
-    "@std/ulid": "jsr:@std/ulid@^1.0.0"
+    "@std/ulid": "jsr:@std/ulid@^1.0.0",
+    "@std/assert": "jsr:@std/assert@^1.0.0"
   },
   "tasks": {
     "dev": "deno run --unstable-kv --allow-net --allow-env --allow-read --watch server.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,10 +1,22 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/ulid@*": "1.0.0",
     "jsr:@std/ulid@1": "1.0.0"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
     "@std/ulid@1.0.0": {
       "integrity": "d41c3d27a907714413649fee864b7cde8d42ee68437d22b79d5de4f81d808780"
     }
@@ -32,6 +44,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@std/assert@1",
       "jsr:@std/ulid@1"
     ]
   }


### PR DESCRIPTION
## Summary
- colors モジュールのユニットテストを追加 (`backgroundColor` / `textColor` / `squareColors`)
- テスト実装時に発覚した `colors.ts` の型不整合を修正

## Why
quality-loop (cycle 1) での分析で、Deno 側にテストファイルが 0 本であることが判明。純粋関数のみで構成された `colors.ts` を最初のサイクル対象として選定。

テスト実行 (`deno test`) で既存 `colors.ts` の型チェックが失敗することも判明（`allColors[event]` が `AllColors` を `string` キーでアクセス）。テストが機能する前提条件として同 PR 内で解消。

## How
- `colors.ts`: `theme` / `event` の引数を型付きキー (`Theme` / `Event`) に正規化してから `allColors` を引く。挙動は変えず (`"dark"` 以外は `"light"`, `"halloween"` 以外は `"default"` のフォールバック)
- `colors_test.ts`: theme × event の全組み合わせ、および未知キーのフォールバックを網羅
- `deno.json`: `@std/assert` を imports に追加（lint の `no-import-prefix` 回避のため bare specifier で参照）

## 確認観点
- [x] `deno test colors_test.ts` で 12 ステップすべて pass
- [x] `deno lint colors.ts colors_test.ts` クリア
- [x] `deno fmt --check colors.ts colors_test.ts deno.json` クリア
- [x] `squareColors` の挙動が既存呼び出し箇所 (`renderCanvas.ts`) で変わらない（既存パレットと完全一致を assert で確認）
- [x] `deno.lock` に `@std/assert` の依存が追加されている

> Auto-generated by quality-loop skill (cycle 1, phase: test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)