### PR TITLE
refactor: fix typo makeMohthLabels -> makeMonthLabels

### DIFF
--- a/renderCanvas.ts
+++ b/renderCanvas.ts
@@ -1,7 +1,7 @@
 import { ContributionCalendar, ContributionDay, Week } from "./contributions.ts";
 import { backgroundColor, squareColors, textColor } from "./colors.ts";
 
-const makeMohthLabels = (contribution: ContributionCalendar) => {
+const makeMonthLabels = (contribution: ContributionCalendar) => {
   // deno-fmt-ignore
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
@@ -29,7 +29,7 @@ const renderContributions = (
   const space = 2;
   const size = 10;
 
-  const monthLabels = makeMohthLabels(contribution);
+  const monthLabels = makeMonthLabels(contribution);
 
   ctx.fillStyle = backgroundColor(theme);
   ctx.fillRect(0, 0 + offset, width, height);


### PR DESCRIPTION
## Summary
- `renderCanvas.ts` のローカルヘルパー関数名の typo を修正 (`Moht` → `Month`)

## Why
quality-loop (cycle 1) の探索的リファクタで検出。export されていないローカル関数のため外部影響なし。単純な命名修正だがレビュー時の可読性に寄与する。

## How
- `renderCanvas.ts` 内の 2 箇所（定義 + 呼び出し）を一括リネーム
- 振る舞いの変更なし

## 確認観点
- [x] `deno lint renderCanvas.ts` クリア
- [x] `deno fmt --check renderCanvas.ts` クリア
- [x] 関数が export されていない（他ファイルへの影響なし）
- [ ] CI 上で VRT が通る（既存スナップショットと一致）

> Auto-generated by quality-loop skill (cycle 1, phase: refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)