### PR TITLE
test: add tests for makeMohthLabels (extracted module)

### DIFF
--- a/monthLabels.ts
+++ b/monthLabels.ts
@@ -1,0 +1,15 @@
+import type { ContributionCalendar, Week } from "./contributions.ts";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+const makeMonthLabels = (contribution: ContributionCalendar): string[] => {
+  return contribution.weeks.map((week: Week, i: number, array: Week[]) => {
+    const isBeginningOfMonth = array[i - 1] === undefined ||
+      new Date(week.contributionDays[0].date).getMonth() !==
+        new Date(array[i - 1].contributionDays[0].date).getMonth();
+
+    return isBeginningOfMonth ? MONTHS[new Date(week.contributionDays[0].date).getMonth()] : " ";
+  });
+};
+
+export { makeMonthLabels };

--- a/monthLabels_test.ts
+++ b/monthLabels_test.ts
@@ -1,0 +1,53 @@
+import { assertEquals } from "@std/assert";
+import { makeMonthLabels } from "./monthLabels.ts";
+import type { ContributionCalendar, Week } from "./contributions.ts";
+
+const weekFromFirstDate = (firstDate: string): Week => ({
+  contributionDays: [
+    { color: "", contributionCount: 0, contributionLevel: "NONE", date: firstDate },
+  ],
+});
+
+const calendar = (firstDates: string[]): ContributionCalendar => ({
+  totalContributions: 0,
+  colors: [],
+  weeks: firstDates.map(weekFromFirstDate),
+});
+
+Deno.test("makeMonthLabels", async (t) => {
+  await t.step("empty weeks returns empty array", () => {
+    assertEquals(makeMonthLabels(calendar([])), []);
+  });
+
+  await t.step("first week always gets its month label", () => {
+    assertEquals(makeMonthLabels(calendar(["2024-03-15"])), ["Mar"]);
+  });
+
+  await t.step("consecutive weeks in same month -> label only on first", () => {
+    assertEquals(
+      makeMonthLabels(calendar(["2024-03-08", "2024-03-15", "2024-03-22"])),
+      ["Mar", " ", " "],
+    );
+  });
+
+  await t.step("month boundary emits new label", () => {
+    assertEquals(
+      makeMonthLabels(calendar(["2024-03-22", "2024-03-29", "2024-04-12"])),
+      ["Mar", " ", "Apr"],
+    );
+  });
+
+  await t.step("year boundary (Dec -> Jan) emits January label", () => {
+    assertEquals(
+      makeMonthLabels(calendar(["2023-12-15", "2023-12-22", "2024-01-12"])),
+      ["Dec", " ", "Jan"],
+    );
+  });
+
+  await t.step("same month number across years is treated as no transition (getMonth-only compare)", () => {
+    assertEquals(
+      makeMonthLabels(calendar(["2023-03-15", "2024-03-15"])),
+      ["Mar", " "],
+    );
+  });
+});

--- a/renderCanvas.ts
+++ b/renderCanvas.ts
@@ -1,20 +1,6 @@
 import { ContributionCalendar, ContributionDay, Week } from "./contributions.ts";
 import { backgroundColor, squareColors, textColor } from "./colors.ts";
-
-const makeMonthLabels = (contribution: ContributionCalendar) => {
-  // deno-fmt-ignore
-  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-
-  return contribution.weeks.map(
-    (week: Week, i: number, array: Week[]) => {
-      const isBeginningOfMonth = array[i - 1] === undefined ||
-        new Date(week.contributionDays[0].date).getMonth() !==
-          new Date(array[i - 1].contributionDays[0].date).getMonth();
-
-      return isBeginningOfMonth ? months[new Date(week.contributionDays[0].date).getMonth()] : " ";
-    },
-  );
-};
+import { makeMonthLabels } from "./monthLabels.ts";
 
 const renderContributions = (
   ctx: CanvasRenderingContext2D,


### PR DESCRIPTION
## Summary
- `makeMohthLabels` を `renderCanvas.ts` から独立モジュール `monthLabels.ts` に抽出
- `monthLabels_test.ts` を追加し、月境界・年境界・空ケース・連続月のケースを網羅

## Why
quality-loop (cycle 2) で選定。`makeMohthLabels` は日付→月ラベル変換のピュアロジックだが、`renderCanvas.ts` 内ではローカル関数のためユニットテスト不能だった。

さらに、`renderCanvas.ts` 内には `CanvasRenderingContext2D` / `day.contributionLevel` の既存型エラーがあり、同ファイルから直接 import してテストしようとすると型チェックで落ちる。ピュア部分だけ分離することで、そうした既存問題の影響を受けずにロジックテストが可能になる。

## How
- `monthLabels.ts` を新規作成し、関数定義をそこへ move（振る舞いは同一）
- `renderCanvas.ts` は関数を import する形に変更
- `monthLabels_test.ts` を追加（6 ケース）

### 検証したケース
- 空の weeks → 空配列
- 1 週のみ → 月名が返る
- 同月内の連続週 → 最初の週のみラベル、残りは空白
- 月境界 → 新しい月のラベル
- 年境界 (Dec → Jan)
- 同じ月番号で年が違う → 連続扱い（`getMonth()` のみで比較する現状挙動）

## 確認観点
- [x] `deno test monthLabels_test.ts` で 6 ステップ pass
- [x] `deno lint monthLabels.ts monthLabels_test.ts renderCanvas.ts` クリア
- [x] `deno fmt --check` クリア
- [x] `renderContributions` の呼び出し経路は変わらない（import の差し替えのみ）
- [ ] CI 上で VRT が通る（抽出前後で画像一致）

## Base
PR #134 (`test/colors`) の変更（`@std/assert` 追加、`colors.ts` 型修正）に依存するため、base を `test/colors` にスタック。#134 のマージ後に自動で main へ rebase される。

> Auto-generated by quality-loop skill (cycle 2, phase: test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)