### PR TITLE
test: add tests for logger module

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,7 @@
   },
   "tasks": {
     "dev": "deno run --unstable-kv --allow-net --allow-env --allow-read --watch server.ts",
+    "test": "deno test --unstable-kv",
     "deploy": "deployctl deploy --project=kusa-image --prod server.ts",
     "fmt-check": "deno fmt --check"
   },

--- a/logger.ts
+++ b/logger.ts
@@ -2,6 +2,8 @@ import { ulid } from "@std/ulid";
 
 const EXPIRE_LOGS_DAYS = 90;
 
+type AdditionalData = Record<string, unknown>;
+
 const logObject = async (now: Date, req: Request) => {
   const ts = Math.floor(now.getTime() / 1000);
 
@@ -16,14 +18,16 @@ const logObject = async (now: Date, req: Request) => {
   };
 };
 
-const log = async (request: Request, additionalData) => {
-  const kv = await Deno.openKv();
+const log = async (request: Request, additionalData: AdditionalData, kv?: Deno.Kv) => {
+  const resolvedKv = kv ?? (await Deno.openKv());
   const now = new Date();
   const logRecord = { ...(await logObject(now, request)), ...additionalData };
 
-  return await kv.set(["logs", now.getFullYear(), now.getMonth() + 1, now.getDate(), ulid()], logRecord, {
-    expireIn: 1000 * 60 * 60 * 24 * EXPIRE_LOGS_DAYS,
-  });
+  return await resolvedKv.set(
+    ["logs", now.getFullYear(), now.getMonth() + 1, now.getDate(), ulid()],
+    logRecord,
+    { expireIn: 1000 * 60 * 60 * 24 * EXPIRE_LOGS_DAYS },
+  );
 };
 
 export { log };

--- a/logger_test.ts
+++ b/logger_test.ts
@@ -1,0 +1,105 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { log } from "./logger.ts";
+
+const collectEntries = async (kv: Deno.Kv) => {
+  const entries: Deno.KvEntry<Record<string, unknown>>[] = [];
+  for await (const entry of kv.list<Record<string, unknown>>({ prefix: ["logs"] })) {
+    entries.push(entry);
+  }
+  return entries;
+};
+
+Deno.test("log", async (t) => {
+  await t.step("stores a record with request metadata and additionalData merged", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const req = new Request("https://example.com/swfz?theme=dark", {
+        method: "GET",
+        headers: { "user-agent": "qa" },
+      });
+
+      const result = await log(req, { user: "swfz", theme: "dark" }, kv);
+
+      assertExists(result.versionstamp);
+
+      const entries = await collectEntries(kv);
+      assertEquals(entries.length, 1);
+
+      const record = entries[0].value;
+      assertEquals(record.method, "GET");
+      assertEquals(record.url, "https://example.com/swfz?theme=dark");
+      assertEquals(record.user, "swfz");
+      assertEquals(record.theme, "dark");
+      assertEquals((record.headers as Record<string, string>)["user-agent"], "qa");
+    } finally {
+      kv.close();
+    }
+  });
+
+  await t.step("stores request body when present", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const body = JSON.stringify({ foo: "bar" });
+      const req = new Request("https://example.com/api", {
+        method: "POST",
+        body,
+        headers: { "content-type": "application/json" },
+      });
+
+      await log(req, {}, kv);
+
+      const entries = await collectEntries(kv);
+      assertEquals(entries[0].value.body, body);
+    } finally {
+      kv.close();
+    }
+  });
+
+  await t.step("omits body field for requests without body", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const req = new Request("https://example.com/", { method: "GET" });
+
+      await log(req, {}, kv);
+
+      const entries = await collectEntries(kv);
+      assertEquals("body" in entries[0].value, false);
+    } finally {
+      kv.close();
+    }
+  });
+
+  await t.step("uses year/month/day in key path", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const req = new Request("https://example.com/");
+
+      await log(req, {}, kv);
+
+      const entries = await collectEntries(kv);
+      const [prefix, year, month, day, id] = entries[0].key;
+      assertEquals(prefix, "logs");
+      const now = new Date();
+      assertEquals(year, now.getFullYear());
+      assertEquals(month, now.getMonth() + 1);
+      assertEquals(day, now.getDate());
+      assertEquals(typeof id, "string");
+    } finally {
+      kv.close();
+    }
+  });
+
+  await t.step("additionalData overrides request metadata on key collision", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const req = new Request("https://example.com/", { method: "GET" });
+
+      await log(req, { method: "OVERRIDDEN" }, kv);
+
+      const entries = await collectEntries(kv);
+      assertEquals(entries[0].value.method, "OVERRIDDEN");
+    } finally {
+      kv.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `logger.ts` に KV 依存注入ポイントを追加し、`additionalData` を型付けした
- `deno.json` tasks に `test` を追加 (Deno KV の `--unstable-kv` フラグを包む)
- `logger_test.ts` で in-memory KV を使って 5 ケースをテスト

## Why
quality-loop (cycle 3) の対象として選定。`log()` は直近 PR #68 で追加されたがテストなし。`Deno.openKv()` が関数内でハードコードされていたためモック不能で、まず最小リファクタで注入可能に。

## How
- `log(request, additionalData, kv?)` — KV を optional 引数で受け取り、未指定なら `Deno.openKv()` を開く。既存呼び出し側 (`server.ts`) は変更不要
- `additionalData` は `Record<string, unknown>` と型付け（以前は implicit any）
- `deno.json` に `"test": "deno test --unstable-kv"` タスク。フラグを忘れずに付けて走らせるため

## 検証したケース
- リクエストメタデータと additionalData のマージ
- body のある/なし 2 分岐
- KV キーが `["logs", year, month+1, day, ulid]` 形式
- additionalData がリクエスト由来フィールドを上書きする（挙動を仕様として固定）

## 確認観点
- [x] `deno task test logger_test.ts` で 5 ステップ pass
- [x] `deno lint logger.ts logger_test.ts` クリア
- [x] `deno fmt --check logger.ts logger_test.ts deno.json` クリア
- [x] 既存の `server.ts` 呼び出しが壊れない（`kv` が optional）
- [x] テストは `:memory:` KV を使い永続ストアに触れない

## Base
PR #134 (`test/colors`) の `@std/assert` 追加に依存するため base を `test/colors` にスタック。PR #134 マージ後に自動で main へ rebase される。

> Auto-generated by quality-loop skill (cycle 3, phase: test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)