### PR TITLE
test(contributions): add tests for getContributions

### DIFF
--- a/contributions_test.ts
+++ b/contributions_test.ts
@@ -1,0 +1,172 @@
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { getContributions } from "./contributions.ts";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const stubFetch = (responseFactory: () => Response) => {
+  const calls: Request[] = [];
+  globalThis.fetch = ((input: Request | URL | string, init?: RequestInit) => {
+    const req = input instanceof Request ? input : new Request(input.toString(), init);
+    calls.push(req);
+    return Promise.resolve(responseFactory());
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = ORIGINAL_FETCH;
+    },
+  };
+};
+
+const okResponse = (payload: unknown) =>
+  new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+
+const errorResponse = () =>
+  new Response(JSON.stringify({ errors: [{ message: "server error" }] }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+
+const samplePayload = (totalContributions: number) => ({
+  data: {
+    user: {
+      contributionsCollection: {
+        contributionCalendar: {
+          totalContributions,
+          colors: [],
+          isHalloween: false,
+          weeks: [],
+        },
+      },
+    },
+  },
+});
+
+let userCounter = 0;
+const uniqueUser = (label: string) => {
+  userCounter += 1;
+  return `qa-${label}-${userCounter}-${Date.now()}`;
+};
+
+Deno.test("getContributions", async (t) => {
+  await t.step("issues POST with Authorization header and GraphQL variables", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(1)));
+    try {
+      const user = uniqueUser("post");
+      await getContributions(false, user, "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z");
+
+      assertEquals(stub.calls.length, 1);
+      const req = stub.calls[0];
+      assertEquals(req.method, "POST");
+      assertEquals(req.headers.get("content-type"), "application/json");
+      assert(req.headers.get("Authorization")?.startsWith("Bearer "), "Authorization should be Bearer-prefixed");
+
+      const body = await req.json();
+      assertExists(body.query);
+      assertEquals(body.variables, {
+        user,
+        from: "2024-01-01T00:00:00Z",
+        to: "2024-12-31T23:59:59Z",
+      });
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("returns parsed JSON body from fetch response", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(42)));
+    try {
+      const result = await getContributions(false, uniqueUser("json"));
+      assertEquals(result.data.user.contributionsCollection.contributionCalendar.totalContributions, 42);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("useCache=true with from+to caches response and skips fetch on second call", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(7)));
+    try {
+      const user = uniqueUser("cache-hit");
+      const from = "2024-01-01T00:00:00Z";
+      const to = "2024-12-31T23:59:59Z";
+
+      const first = await getContributions(true, user, from, to);
+      const second = await getContributions(true, user, from, to);
+
+      assertEquals(stub.calls.length, 1, "second call should use cache");
+      assertEquals(first.data.user.contributionsCollection.contributionCalendar.totalContributions, 7);
+      assertEquals(second.data.user.contributionsCollection.contributionCalendar.totalContributions, 7);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("useCache=false always fetches even when an entry could be cached", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(3)));
+    try {
+      const user = uniqueUser("nocache");
+      const from = "2024-01-01T00:00:00Z";
+      const to = "2024-12-31T23:59:59Z";
+
+      await getContributions(false, user, from, to);
+      await getContributions(false, user, from, to);
+
+      assertEquals(stub.calls.length, 2);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("useCache=true but from is undefined → response is NOT cached", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(5)));
+    try {
+      const user = uniqueUser("no-from");
+
+      await getContributions(true, user, undefined, "2024-12-31T23:59:59Z");
+      await getContributions(true, user, undefined, "2024-12-31T23:59:59Z");
+
+      assertEquals(stub.calls.length, 2, "missing 'from' should bypass cache.put");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("useCache=true but to is undefined → response is NOT cached", async () => {
+    const stub = stubFetch(() => okResponse(samplePayload(5)));
+    try {
+      const user = uniqueUser("no-to");
+
+      await getContributions(true, user, "2024-01-01T00:00:00Z", undefined);
+      await getContributions(true, user, "2024-01-01T00:00:00Z", undefined);
+
+      assertEquals(stub.calls.length, 2, "missing 'to' should bypass cache.put");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  await t.step("useCache=true but fetch returns non-ok → response is NOT cached", async () => {
+    let callCount = 0;
+    const stub = stubFetch(() => {
+      callCount += 1;
+      return callCount === 1 ? errorResponse() : okResponse(samplePayload(9));
+    });
+    try {
+      const user = uniqueUser("err");
+      const from = "2024-01-01T00:00:00Z";
+      const to = "2024-12-31T23:59:59Z";
+
+      const first = await getContributions(true, user, from, to);
+      const second = await getContributions(true, user, from, to);
+
+      assertEquals(stub.calls.length, 2, "non-ok response should bypass cache.put");
+      assertExists((first as Record<string, unknown>).errors, "first call returns parsed error body");
+      assertEquals(second.data.user.contributionsCollection.contributionCalendar.totalContributions, 9);
+    } finally {
+      stub.restore();
+    }
+  });
+});

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
   },
   "tasks": {
     "dev": "deno run --unstable-kv --allow-net --allow-env --allow-read --watch server.ts",
-    "test": "deno test --unstable-kv",
+    "test": "deno test --unstable-kv --allow-env",
     "deploy": "deployctl deploy --project=kusa-image --prod server.ts",
     "fmt-check": "deno fmt --check"
   },


### PR DESCRIPTION
## Summary
- `contributions.ts` の `getContributions` に対して、キャッシュ動作・リクエスト形状を検証する単体テストを追加
- `globalThis.fetch` を stub し、step ごとに一意な user 値で cache 衝突を回避
- 副次変更: `deno.json` の test task に `--allow-env` を追加（モジュール top-level の `Deno.env.get(\"CI\")` のため）

## テストケース ( 7 ステップ pass )
1. fetch リクエスト形状 → method=POST / content-type=application/json / Authorization Bearer-prefixed / body.variables = {user, from, to}
2. okResponse(payload) を渡すと payload が parse されて返る → totalContributions == 42
3. useCache=true & from+to あり & res.ok → 同条件 2 回目で fetch.calls=1（cache hit）
4. useCache=false → 同条件 2 回連続呼びで fetch.calls=2（キャッシュ無視）
5. useCache=true & from=undefined → fetch.calls=2（cache.put 条件 from が満たされない）
6. useCache=true & to=undefined   → fetch.calls=2（cache.put 条件 to が満たされない）
7. useCache=true & res.ok=false   → fetch.calls=2（cache.put 条件 res.ok が満たされない）

## Test plan
- [x] \`deno task test\` が pass する（30 ステップ）
- [x] \`deno lint contributions_test.ts\` が pass
- [x] \`deno task fmt-check\` が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)