### PR TITLE
refactor: hoist fixPastYears and dedupe canvas cell stride

### DIFF
--- a/renderCanvas.ts
+++ b/renderCanvas.ts
@@ -31,19 +31,17 @@ const renderContributions = (
 
   const colors = squareColors(theme, event);
 
+  const cellStride = space + size;
+
   contribution.weeks.forEach((week: Week, i: number) => {
+    const x = 20 + cellStride * i;
     ctx.fillStyle = textColor(theme);
-    ctx.fillText(monthLabels[i], 20 + (space * i) + (size * i), 25 + offset);
+    ctx.fillText(monthLabels[i], x, 25 + offset);
 
     week.contributionDays.forEach((day: ContributionDay, j: number, arr: ContributionDay[]) => {
       const jIndex = i === 0 ? 7 - arr.length + j : j;
       ctx.fillStyle = colors[day.contributionLevel];
-      ctx.fillRect(
-        20 + (space * i) + (size * i),
-        30 + (space * jIndex) + (size * jIndex) + offset,
-        size,
-        size,
-      );
+      ctx.fillRect(x, 30 + cellStride * jIndex + offset, size, size);
     });
   });
 
@@ -54,7 +52,7 @@ const renderContributions = (
   ctx.fillText("More", 595, 128 + offset);
   legend.forEach((color: string, i: number) => {
     ctx.fillStyle = color;
-    ctx.fillRect(530 + (space * i) + (size * i), 120 + offset, size, size);
+    ctx.fillRect(530 + cellStride * i, 120 + offset, size, size);
   });
 };
 

--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,16 @@ import { log } from "./logger.ts";
 
 const port = 8080;
 
+const GITHUB_LAUNCH_YEAR = 2008;
+
+const fixPastYears = (pastYearsParam: string): number => {
+  const limit = new Date().getFullYear() - GITHUB_LAUNCH_YEAR + 1;
+  const parsed = parseInt(pastYearsParam);
+  const num = parsed ? parsed : 1;
+
+  return num > limit ? limit : num;
+};
+
 const handler = async (request: Request): Promise<Response> => {
   const url = new URL(request.url);
   const user = url.pathname.split("/").filter((p) => p.length > 0)[0] ?? url.searchParams.get("user") ?? null;
@@ -19,14 +29,6 @@ const handler = async (request: Request): Promise<Response> => {
     const html = await Deno.readFile("./public/index.html");
     return new Response(html, { headers: { "content-type": "text/html" } });
   }
-
-  const fixPastYears = (pastYearsParam) => {
-    // 2008 is start GitHub
-    const limit = new Date().getFullYear() - 2008 + 1;
-    const num = parseInt(pastYearsParam) ? parseInt(pastYearsParam) : 1;
-
-    return num > limit ? limit : num;
-  };
 
   const lineHeight = 140;
   const canvasHeight = pastYears ? fixPastYears(pastYears) * lineHeight : lineHeight;


### PR DESCRIPTION
## Summary
- `server.ts`: `fixPastYears` を handler スコープから外に出し、リクエストごとに再生成されないようにした。引数の型注釈を追加し、`2008` マジックナンバーを `GITHUB_LAUNCH_YEAR` 定数に切り出し、`parseInt` 二重呼びを 1 回に整理。
- `renderCanvas.ts`: `(space * i) + (size * i)` 形式の重複を `cellStride = space + size` 定数で 1 表現に集約。週/日/legend のループで再利用。代数的に等価なので描画結果は不変。

## 振る舞いに影響なし
- ロジック変更は 0。`fixPastYears` の出力は同一、canvas の各座標も `(space * i) + (size * i) === (space + size) * i` で同一値。
- 既存テスト( `deno task test` 23 ステップ ) と `deno task fmt-check` がローカルで pass。

## Test plan
- [x] `deno task test` が pass
- [x] `deno task fmt-check` が pass
- [ ] CI の VRT が回帰しないことを確認(計算式が代数的同値なので想定上は影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)