### PR TITLE
fix(security): strip sensitive headers before persisting request log

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -2,6 +2,27 @@ import { ulid } from "@std/ulid";
 
 const EXPIRE_LOGS_DAYS = 90;
 
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-forwarded-for",
+  "x-real-ip",
+  "cf-connecting-ip",
+  "true-client-ip",
+]);
+
+const sanitizeHeaders = (headers: Headers): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const [key, value] of headers.entries()) {
+    if (!SENSITIVE_HEADERS.has(key.toLowerCase())) {
+      result[key] = value;
+    }
+  }
+  return result;
+};
+
 type AdditionalData = Record<string, unknown>;
 
 const logObject = async (now: Date, req: Request) => {
@@ -13,7 +34,7 @@ const logObject = async (now: Date, req: Request) => {
     redirect: req.redirect,
     bodyUsed: req.bodyUsed,
     ...{ ts: ts },
-    headers: Object.fromEntries(req.headers.entries()),
+    headers: sanitizeHeaders(req.headers),
     ...(req.body ? { body: await req.text() } : {}),
   };
 };

--- a/logger_test.ts
+++ b/logger_test.ts
@@ -89,6 +89,36 @@ Deno.test("log", async (t) => {
     }
   });
 
+  await t.step("sanitizes sensitive headers (Authorization, Cookie, IP-forwarding) from stored record", async () => {
+    const kv = await Deno.openKv(":memory:");
+    try {
+      const req = new Request("https://example.com/", {
+        method: "GET",
+        headers: {
+          "authorization": "Bearer secret-token",
+          "cookie": "session=abc",
+          "x-forwarded-for": "203.0.113.1",
+          "cf-connecting-ip": "203.0.113.1",
+          "user-agent": "qa",
+          "accept-language": "ja",
+        },
+      });
+
+      await log(req, {}, kv);
+
+      const entries = await collectEntries(kv);
+      const headers = entries[0].value.headers as Record<string, string>;
+      assertEquals(headers.authorization, undefined);
+      assertEquals(headers.cookie, undefined);
+      assertEquals(headers["x-forwarded-for"], undefined);
+      assertEquals(headers["cf-connecting-ip"], undefined);
+      assertEquals(headers["user-agent"], "qa");
+      assertEquals(headers["accept-language"], "ja");
+    } finally {
+      kv.close();
+    }
+  });
+
   await t.step("additionalData overrides request metadata on key collision", async () => {
     const kv = await Deno.openKv(":memory:");
     try {


### PR DESCRIPTION
## Summary
- `logger.ts` の \`Object.fromEntries(req.headers.entries())\` で全リクエストヘッダを KV (TTL 90 日) に保存していた問題を修正。
- \`Authorization\` / \`Cookie\` / \`Set-Cookie\` / IP 転送系 (\`X-Forwarded-For\`, \`X-Real-IP\`, \`CF-Connecting-IP\`, \`True-Client-IP\`) / \`Proxy-Authorization\` を denylist で除外。
- 機微ヘッダがログから外れることを担保する回帰テストを追加。

## 影響範囲
- 既存ログ KV エントリは変更なし(将来書き込みのみフィルタ適用)。
- 振る舞いの後方互換性: フィルタで除外したヘッダ以外はそのまま記録されるため、観測用途には影響しない見込み。

## テストケース ( 1 ステップ追加, 計 6 ステップ pass for log )
- 入力: Authorization / Cookie / X-Forwarded-For / CF-Connecting-IP / User-Agent / Accept-Language を含むリクエスト
- 期待値:
  - 機微 4 ヘッダは KV record.headers に存在しない (\`undefined\`)
  - User-Agent / Accept-Language は元の値で保存される

## Test plan
- [x] \`deno task test\` 24 ステップ pass
- [x] \`deno lint\` pass
- [x] \`deno task fmt-check\` pass

## バックログ進捗
- [x] High: logger.ts ヘッダ全件保存
- [ ] Medium: server.ts 404 reflected XSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)