### PR TITLE
test(pastYears): extract fixPastYears and cover its branches

### DIFF
--- a/pastYears.ts
+++ b/pastYears.ts
@@ -1,0 +1,11 @@
+const GITHUB_LAUNCH_YEAR = 2008;
+
+const fixPastYears = (pastYearsParam: string): number => {
+  const limit = new Date().getFullYear() - GITHUB_LAUNCH_YEAR + 1;
+  const parsed = parseInt(pastYearsParam);
+  const num = parsed ? parsed : 1;
+
+  return num > limit ? limit : num;
+};
+
+export { fixPastYears, GITHUB_LAUNCH_YEAR };

--- a/pastYears_test.ts
+++ b/pastYears_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import { fixPastYears, GITHUB_LAUNCH_YEAR } from "./pastYears.ts";
+
+const upperLimit = new Date().getFullYear() - GITHUB_LAUNCH_YEAR + 1;
+
+Deno.test("fixPastYears", async (t) => {
+  await t.step('valid numeric string "3" returns 3', () => {
+    assertEquals(fixPastYears("3"), 3);
+  });
+
+  await t.step('"1" returns 1', () => {
+    assertEquals(fixPastYears("1"), 1);
+  });
+
+  await t.step("empty string falls back to 1 (parseInt NaN)", () => {
+    assertEquals(fixPastYears(""), 1);
+  });
+
+  await t.step("non-numeric string falls back to 1 (parseInt NaN)", () => {
+    assertEquals(fixPastYears("abc"), 1);
+  });
+
+  await t.step('"0" falls back to 1 (parseInt result is falsy)', () => {
+    assertEquals(fixPastYears("0"), 1);
+  });
+
+  await t.step('trailing non-digits are ignored ("5abc" -> 5)', () => {
+    assertEquals(fixPastYears("5abc"), 5);
+  });
+
+  await t.step("values above the current-year limit are clamped", () => {
+    assertEquals(fixPastYears("999"), upperLimit);
+  });
+
+  await t.step("value equal to the limit passes through", () => {
+    assertEquals(fixPastYears(String(upperLimit)), upperLimit);
+  });
+});

--- a/server.ts
+++ b/server.ts
@@ -2,18 +2,9 @@ import { createCanvas } from "./deps.ts";
 import { getContributions } from "./contributions.ts";
 import { renderContributions } from "./renderCanvas.ts";
 import { log } from "./logger.ts";
+import { fixPastYears } from "./pastYears.ts";
 
 const port = 8080;
-
-const GITHUB_LAUNCH_YEAR = 2008;
-
-const fixPastYears = (pastYearsParam: string): number => {
-  const limit = new Date().getFullYear() - GITHUB_LAUNCH_YEAR + 1;
-  const parsed = parseInt(pastYearsParam);
-  const num = parsed ? parsed : 1;
-
-  return num > limit ? limit : num;
-};
 
 const handler = async (request: Request): Promise<Response> => {
   const url = new URL(request.url);


### PR DESCRIPTION
## Summary
- \`server.ts\` に置かれていた \`fixPastYears\` (と \`GITHUB_LAUNCH_YEAR\`) を新ファイル \`pastYears.ts\` に抽出。import するだけで \`Deno.serve\` が走らない純粋モジュールにしたのでテスト容易。
- ブランチ条件(parseInt NaN fallback / parseInt falsy fallback / 数字以降無視 / 上限 clamp / 上限等値)をカバー。
- 振る舞い不変。server.ts は同じ実装を import して使う。

## テストケース ( 8 ステップ pass )
1. "3" → 3
2. "1" → 1
3. "" → 1 (parseInt NaN fallback)
4. "abc" → 1 (parseInt NaN fallback)
5. "0" → 1 (parseInt 結果 0 が falsy で fallback 発火)
6. "5abc" → 5 (parseInt は非数字で停止)
7. "999" → upperLimit = currentYear - 2008 + 1 (上限 clamp)
8. String(upperLimit) → upperLimit (境界 pass-through)

## Test plan
- [x] \`deno task test\` 38 ステップ pass
- [x] \`deno lint\` pass
- [x] \`deno task fmt-check\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)