### PR TITLE
fix(security): set text/plain content-type on 404 user-not-found response

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -59,6 +59,7 @@ const handler = async (request: Request): Promise<Response> => {
     if (data?.data?.user === null) {
       return new Response(`Could not resolve to a User. ${user}`, {
         status: 404,
+        headers: { "content-type": "text/plain; charset=utf-8" },
       });
     }
 


### PR DESCRIPTION
## Summary
- \`server.ts\` の 404 \"Could not resolve to a User\" レスポンスに \`content-type: text/plain; charset=utf-8\` を付与
- 従来は content-type 未設定で user 入力を body に反射していたため、ブラウザの content sniffing 次第で reflected XSS 経路となる可能性があった
- 本文は変更せず、text/plain にすることで user 値が HTML として解釈されないようにする

## 回帰テスト
本 PR では追加しない。server.ts は top-level で \`Deno.serve\` を呼ぶため、import するとテスト実行中にサーバーが起動してしまう。handler をテストハーネス化する別サイクルで回帰テストを補強する予定。

## バックログ進捗
- [x] High: logger.ts ヘッダ全件保存 (PR #141)
- [x] Medium: server.ts 404 reflected XSS (本 PR)

## Test plan
- [x] \`deno task test\` 30 ステップ pass (既存テスト regression なし)
- [x] \`deno lint\` pass
- [x] \`deno task fmt-check\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)